### PR TITLE
Updating project to support ES 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # NFL Elasticsearch Aggregations
 
 This repository contains the files for the [data visualization tutorial](http://www.elasticsearch.org/blog/data-visualization-elasticsearch-aggregations/) using Elasticsearch aggregations (1.4 release) and D3.
+
 Note that starting with Elasticsearch 1.4, Cross Origin Resource Sharing (cors) was determined to be a serious security vulnerability (CVE-2014-6439) which breaks legacy web frontends like the sample index.html code in this demo. To address this, run the "enable_cors.sh" script which appens the necessary commands to elasticsearch.yml running on UNIX. If you are running on a Windows machine, you will need to enter the contents of the script manually into your elasticsearch.yml file.
 
 Additional note:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the files for the [data visualization tutorial](http://www.elasticsearch.org/blog/data-visualization-elasticsearch-aggregations/) using Elasticsearch aggregations (1.4 release) and D3.
 
-Note that starting with Elasticsearch 1.4, Cross Origin Resource Sharing (cors) was determined to be a serious security vulnerability (CVE-2014-6439) which breaks legacy web frontends like the sample index.html code in this demo. To address this, run the "enable_cors.sh" script which appens the necessary commands to elasticsearch.yml running on UNIX. If you are running on a Windows machine, you will need to enter the contents of the script manually into your elasticsearch.yml file.
+Note that starting with Elasticsearch 1.4, Cross Origin Resource Sharing (cors) was determined to be a serious security vulnerability (CVE-2014-6439) which breaks legacy web frontends like the sample index.html code in this demo. To address this, run the "enable_cors.sh" script which appends the necessary commands to elasticsearch.yml running on UNIX. If you are running on a Windows machine, you will need to enter the contents of the script manually into your elasticsearch.yml file.
 
 Additional note:
 This demo can be run using the website scripts in this github project, but the script sources link in the original ES documentation(http://www.elasticsearch.org/blog/data-visualization-elasticsearch-aggregations/) no longerserve the correct scripts. Bottom line, clone this project to obtain all necessary and working files. 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # NFL Elasticsearch Aggregations
 
-This repository contains the files for the [data visualization tutorial](http://www.elasticsearch.org/blog/data-visualization-elasticsearch-aggregations/) using Elasticsearch aggregations (1.0 release) and D3.
+This repository contains the files for the [data visualization tutorial](http://www.elasticsearch.org/blog/data-visualization-elasticsearch-aggregations/) using Elasticsearch aggregations (1.4 release) and D3.
+Note that starting with Elasticsearch 1.4, Cross Origin Resource Sharing (cors) was determined to be a serious security vulnerability (CVE-2014-6439) which breaks legacy web frontends like the sample index.html code in this demo. To address this, run the "enable_cors.sh" script which appens the necessary commands to elasticsearch.yml running on UNIX. If you are running on a Windows machine, you will need to enter the contents of the script manually into your elasticsearch.yml file.
+
+Additional note:
+This demo can be run using the website scripts in this github project, but the script sources link in the original ES documentation(http://www.elasticsearch.org/blog/data-visualization-elasticsearch-aggregations/) no longerserve the correct scripts. Bottom line, clone this project to obtain all necessary and working files. 

--- a/enable_cors.sh
+++ b/enable_cors.sh
@@ -1,0 +1,5 @@
+cat >> /etc/elasticsearch/elasticsearch.yml << EOF
+################################# Custom ##################################
+http.cors.allow-origin: "/.*/"
+http.cors.enabled: true
+EOF

--- a/webserver.js
+++ b/webserver.js
@@ -1,0 +1,44 @@
+# node.js webserver script
+# This is not required for the project but useful if you opt to use node as your webserver
+# Instructions
+# Install node.js
+# From a command line run "node webserver.js"
+
+
+var http = require("http"),
+    url = require("url"),
+    path = require("path"),
+    fs = require("fs")
+    port = process.argv[2] || 80;
+
+http.createServer(function(request, response) {
+
+  var uri = url.parse(request.url).pathname
+    , filename = path.join(process.cwd(), uri);
+  
+  path.exists(filename, function(exists) {
+    if(!exists) {
+      response.writeHead(404, {"Content-Type": "text/plain"});
+      response.write("404 Not Found\n");
+      response.end();
+      return;
+    }
+
+    if (fs.statSync(filename).isDirectory()) filename += '/index.html';
+
+    fs.readFile(filename, "binary", function(err, file) {
+      if(err) {        
+        response.writeHead(500, {"Content-Type": "text/plain"});
+        response.write(err + "\n");
+        response.end();
+        return;
+      }
+
+      response.writeHead(200);
+      response.write(file, "binary");
+      response.end();
+    });
+  });
+}).listen(parseInt(port, 10));
+
+console.log("Static file server running at\n  => http://localhost:" + port + "/\nCTRL + C to shutdown");

--- a/webserver.js
+++ b/webserver.js
@@ -1,10 +1,3 @@
-# node.js webserver script
-# This is not required for the project but useful if you opt to use node as your webserver
-# Instructions
-# Install node.js
-# From a command line run "node webserver.js"
-
-
 var http = require("http"),
     url = require("url"),
     path = require("path"),


### PR DESCRIPTION
Includes script that modifies elasticsearch.yml to disable cors so that a web frontend can access ES 1.4 (and likely later). The script can simply be executed on a Linux deployment. Script contents will need to be manually entered into elasticsearch.yml on a Windows deployment.

Modifies README.md, updating to reflect changes since the ES documentation was first published.
Added fix minor typo "appens" > "appends"
